### PR TITLE
docs: update tutorial link to point to the correct URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Check out this demo video to get a first impression of what nut.js is capable of
 
 # Tutorials
 
-Please consult the project website at [nutjs.dev](https://nutjs.dev/docs/tutorial-first_steps/prerequisites) for in-depth tutorials
+Please consult the project website at [nutjs.dev](https://nutjs.dev/tutorials/first_steps#prerequisites) for in-depth tutorials
 
 # API Docs
 


### PR DESCRIPTION
Updated the tutorial links in the README to point to the correct URL for in-depth tutorials.