### PR TITLE
Bind all class methods using the keyword "this"

### DIFF
--- a/core/nut.js/lib/assert.class.ts
+++ b/core/nut.js/lib/assert.class.ts
@@ -5,11 +5,11 @@ export class AssertClass {
   constructor(private screen: ScreenClass) {
   }
 
-  public async isVisible(
+  public isVisible = async (
     searchInput: FindInput | Promise<FindInput>,
     searchRegion?: Region | Promise<Region>,
     confidence?: number
-  ): Promise<void> {
+  ): Promise<void> => {
     const needle = await searchInput;
     const identifier = needle.id;
 
@@ -29,11 +29,11 @@ export class AssertClass {
     }
   }
 
-  public async notVisible(
+  public notVisible = async (
     searchInput: FindInput | Promise<FindInput>,
     searchRegion?: Region | Promise<Region>,
     confidence?: number
-  ) {
+  ) => {
     const needle = await searchInput;
     const identifier = needle.id;
 

--- a/core/nut.js/lib/clipboard.class.ts
+++ b/core/nut.js/lib/clipboard.class.ts
@@ -15,7 +15,7 @@ export class ClipboardClass {
    * {@link setContent} copies a given text to the system clipboard
    * @param text The text to copy
    */
-  public async setContent(text: string): Promise<void> {
+  public setContent = async (text: string): Promise<void> => {
     await this.providerRegistry.getClipboard().copy(text);
     this.providerRegistry.getLogProvider().debug(`Saved to clipboard`);
   }
@@ -23,7 +23,7 @@ export class ClipboardClass {
   /**
    * {@link getContent} returns the current content of the system clipboard (limited to text)
    */
-  public async getContent(): Promise<string> {
+  public getContent = async (): Promise<string> => {
     const content = await this.providerRegistry.getClipboard().paste();
     this.providerRegistry.getLogProvider().debug(`Fetched clipboard content`);
     return content;

--- a/core/nut.js/lib/keyboard.class.ts
+++ b/core/nut.js/lib/keyboard.class.ts
@@ -51,7 +51,7 @@ export class KeyboardClass {
    *
    * @param input Sequence of {@link String} or {@link Key} to type
    */
-  public async type(...input: StringOrKey): Promise<KeyboardClass> {
+  public type = async (...input: StringOrKey): Promise<KeyboardClass> => {
     try {
       if (inputIsString(input)) {
         for (const char of input.join(" ")) {
@@ -88,7 +88,7 @@ export class KeyboardClass {
    *
    * @param keys Array of {@link Key}s to press and hold
    */
-  public async pressKey(...keys: Key[]): Promise<KeyboardClass> {
+  public pressKey = async (...keys: Key[]): Promise<KeyboardClass> => {
     try {
       await sleep(this.config.autoDelayMs);
       await this.providerRegistry.getKeyboard().pressKey(...keys);
@@ -112,7 +112,7 @@ export class KeyboardClass {
    *
    * @param keys Array of {@link Key}s to release
    */
-  public async releaseKey(...keys: Key[]): Promise<KeyboardClass> {
+  public releaseKey = async (...keys: Key[]): Promise<KeyboardClass> => {
     try {
       await sleep(this.config.autoDelayMs);
       await this.providerRegistry.getKeyboard().releaseKey(...keys);

--- a/core/nut.js/lib/mouse.class.ts
+++ b/core/nut.js/lib/mouse.class.ts
@@ -41,7 +41,7 @@ export class MouseClass {
    * {@link setPosition} instantly moves the mouse cursor to a given {@link Point}
    * @param target {@link Point} to move the cursor to
    */
-  public async setPosition(target: Point): Promise<MouseClass> {
+  public setPosition = async (target: Point): Promise<MouseClass> => {
     if (!isPoint(target)) {
       const e = new Error(
         `setPosition requires a Point, but received ${JSON.stringify(target)}`
@@ -64,7 +64,7 @@ export class MouseClass {
   /**
    * {@link getPosition} returns a {@link Point} representing the current mouse position
    */
-  public async getPosition(): Promise<Point> {
+  public getPosition = async (): Promise<Point> => {
     const currentPosition = await this.providerRegistry
       .getMouse()
       .currentMousePosition();
@@ -79,10 +79,10 @@ export class MouseClass {
    * @param path Array of {@link Point}s to follow
    * @param movementType Defines the type of mouse movement. Would allow to configured acceleration etc. (Default: {@link linear}, no acceleration)
    */
-  public async move(
+  public move = async (
     path: Point[] | Promise<Point[]>,
     movementType: EasingFunction = linear
-  ): Promise<MouseClass> {
+  ): Promise<MouseClass> => {
     try {
       let pathSteps = await path;
       if (!Array.isArray(pathSteps)) {
@@ -114,14 +114,14 @@ export class MouseClass {
   /**
    * {@link leftClick} performs a click with the left mouse button
    */
-  public async leftClick(): Promise<MouseClass> {
+  public leftClick = async (): Promise<MouseClass> => {
     return this.click(Button.LEFT);
   }
 
   /**
    * {@link rightClick} performs a click with the right mouse button
    */
-  public async rightClick(): Promise<MouseClass> {
+  public rightClick = async (): Promise<MouseClass> => {
     return this.click(Button.RIGHT);
   }
 
@@ -130,7 +130,7 @@ export class MouseClass {
    * Please note that the actual scroll distance of a single "step" is OS dependent
    * @param amount The amount of "steps" to scroll
    */
-  public async scrollDown(amount: number): Promise<MouseClass> {
+  public scrollDown = async (amount: number): Promise<MouseClass> => {
     try {
       await sleep(this.config.autoDelayMs);
       await this.providerRegistry.getMouse().scrollDown(amount);
@@ -149,7 +149,7 @@ export class MouseClass {
    * Please note that the actual scroll distance of a single "step" is OS dependent
    * @param amount The amount of "steps" to scroll
    */
-  public async scrollUp(amount: number): Promise<MouseClass> {
+  public scrollUp = async (amount: number): Promise<MouseClass> => {
     try {
       await sleep(this.config.autoDelayMs);
       await this.providerRegistry.getMouse().scrollUp(amount);
@@ -168,7 +168,7 @@ export class MouseClass {
    * Please note that the actual scroll distance of a single "step" is OS dependent
    * @param amount The amount of "steps" to scroll
    */
-  public async scrollLeft(amount: number): Promise<MouseClass> {
+  public scrollLeft = async (amount: number): Promise<MouseClass> => {
     try {
       await sleep(this.config.autoDelayMs);
       await this.providerRegistry.getMouse().scrollLeft(amount);
@@ -187,7 +187,7 @@ export class MouseClass {
    * Please note that the actual scroll distance of a single "step" is OS dependent
    * @param amount The amount of "steps" to scroll
    */
-  public async scrollRight(amount: number): Promise<MouseClass> {
+  public scrollRight = async (amount: number): Promise<MouseClass> => {
     try {
       await sleep(this.config.autoDelayMs);
       await this.providerRegistry.getMouse().scrollRight(amount);
@@ -206,7 +206,7 @@ export class MouseClass {
    * In summary, {@link drag} presses and holds the left mouse button, moves the mouse and releases the left button
    * @param path The path of {@link Point}s to drag along
    */
-  public async drag(path: Point[] | Promise<Point[]>): Promise<MouseClass> {
+  public drag = async (path: Point[] | Promise<Point[]>): Promise<MouseClass> => {
     try {
       await sleep(this.config.autoDelayMs);
       await this.providerRegistry.getMouse().pressButton(Button.LEFT);
@@ -225,7 +225,7 @@ export class MouseClass {
    * {@link pressButton} presses and holds a mouse button
    * @param btn The {@link Button} to press and hold
    */
-  public async pressButton(btn: Button): Promise<MouseClass> {
+  public pressButton = async (btn: Button): Promise<MouseClass> => {
     try {
       await sleep(this.config.autoDelayMs);
       await this.providerRegistry.getMouse().pressButton(btn);
@@ -244,7 +244,7 @@ export class MouseClass {
    * {@link releaseButton} releases a mouse button previously pressed via {@link pressButton}
    * @param btn The {@link Button} to release
    */
-  public async releaseButton(btn: Button): Promise<MouseClass> {
+  public releaseButton = async (btn: Button): Promise<MouseClass> => {
     try {
       await sleep(this.config.autoDelayMs);
       await this.providerRegistry.getMouse().releaseButton(btn);
@@ -263,7 +263,7 @@ export class MouseClass {
    * {@link click} clicks a mouse button
    * @param btn The {@link Button} to click
    */
-  public async click(btn: Button): Promise<MouseClass> {
+  public click = async (btn: Button): Promise<MouseClass> => {
     try {
       await sleep(this.config.autoDelayMs);
       await this.providerRegistry.getMouse().click(btn);
@@ -282,7 +282,7 @@ export class MouseClass {
    * {@link doubleClick} performs a double click on a mouse button
    * @param btn The {@link Button} to click
    */
-  public async doubleClick(btn: Button): Promise<MouseClass> {
+  public doubleClick = async (btn: Button): Promise<MouseClass> => {
     try {
       await sleep(this.config.autoDelayMs);
       await this.providerRegistry.getMouse().doubleClick(btn);

--- a/core/nut.js/lib/provider/io/jimp-image-reader.class.ts
+++ b/core/nut.js/lib/provider/io/jimp-image-reader.class.ts
@@ -3,7 +3,7 @@ import { ImageReader } from "@nut-tree/provider-interfaces";
 import { ColorMode, Image } from "@nut-tree/shared";
 
 export default class implements ImageReader {
-  load(parameters: string): Promise<Image> {
+  load = (parameters: string): Promise<Image> => {
     return new Promise<Image>((resolve, reject) => {
       Jimp.read(parameters)
         .then((jimpImage) => {

--- a/core/nut.js/lib/provider/log/console-log-provider.class.ts
+++ b/core/nut.js/lib/provider/log/console-log-provider.class.ts
@@ -32,7 +32,7 @@ export class ConsoleLogProvider implements LogProviderInterface {
     this.withTimeStamp = config.withTimeStamp ?? true;
   }
 
-  private log(logLevel: ConsoleLogLevel, message: string | Error, data?: {}) {
+  private log = (logLevel: ConsoleLogLevel, message: string | Error, data?: {}) => {
     if (logLevel >= this.logLevel) {
       const timeStampPrefix = `${new Date().toISOString()} - `;
       const extendedMessage = `${
@@ -81,23 +81,23 @@ export class ConsoleLogProvider implements LogProviderInterface {
     }
   }
 
-  public trace(message: string, data?: {}) {
+  public trace = (message: string, data?: {}) => {
     this.log(ConsoleLogLevel.TRACE, message, data);
   }
 
-  public debug(message: string, data?: {}) {
+  public debug = (message: string, data?: {}) => {
     this.log(ConsoleLogLevel.DEBUG, message, data);
   }
 
-  public info(message: string, data?: {}) {
+  public info = (message: string, data?: {}) => {
     this.log(ConsoleLogLevel.INFO, message, data);
   }
 
-  public warn(message: string, data?: {}) {
+  public warn = (message: string, data?: {}) => {
     this.log(ConsoleLogLevel.WARN, message, data);
   }
 
-  public error(message: Error, data?: {}) {
+  public error = (message: Error, data?: {}) => {
     this.log(ConsoleLogLevel.ERROR, message, data);
   }
 }

--- a/core/nut.js/lib/provider/provider-registry.class.ts
+++ b/core/nut.js/lib/provider/provider-registry.class.ts
@@ -48,7 +48,7 @@ class DefaultProviderRegistry implements ProviderRegistry {
   private _colorFinder?: ColorFinderInterface;
   private _windowElementInspector?: ElementInspectionProviderInterface;
 
-  hasClipboard(): boolean {
+  hasClipboard = (): boolean => {
     return this._clipboard != null;
   }
 
@@ -66,7 +66,7 @@ class DefaultProviderRegistry implements ProviderRegistry {
     this.getLogProvider().trace("Registered new clipboard provider", value);
   };
 
-  hasImageFinder(): boolean {
+  hasImageFinder = (): boolean => {
     return this._imageFinder != null;
   }
 
@@ -84,7 +84,7 @@ class DefaultProviderRegistry implements ProviderRegistry {
     this.getLogProvider().trace("Registered new image finder", value);
   };
 
-  hasKeyboard(): boolean {
+  hasKeyboard = (): boolean => {
     return this._keyboard != null;
   }
 
@@ -102,7 +102,7 @@ class DefaultProviderRegistry implements ProviderRegistry {
     this.getLogProvider().trace("Registered new keyboard provider", value);
   };
 
-  hasMouse(): boolean {
+  hasMouse = (): boolean => {
     return this._mouse != null;
   }
 
@@ -120,7 +120,7 @@ class DefaultProviderRegistry implements ProviderRegistry {
     this.getLogProvider().trace("Registered new mouse provider", value);
   };
 
-  hasScreen(): boolean {
+  hasScreen = (): boolean => {
     return this._screen != null;
   }
 
@@ -138,7 +138,7 @@ class DefaultProviderRegistry implements ProviderRegistry {
     this.getLogProvider().trace("Registered new screen provider", value);
   };
 
-  hasWindow(): boolean {
+  hasWindow = (): boolean => {
     return this._window != null;
   }
 
@@ -156,7 +156,7 @@ class DefaultProviderRegistry implements ProviderRegistry {
     this.getLogProvider().trace("Registered new window provider", value);
   };
 
-  hasTextFinder(): boolean {
+  hasTextFinder = (): boolean => {
     return this._textFinder != null;
   }
 
@@ -174,7 +174,7 @@ class DefaultProviderRegistry implements ProviderRegistry {
     this.getLogProvider().trace("Registered new TextFinder provider", value);
   };
 
-  hasWindowFinder(): boolean {
+  hasWindowFinder = (): boolean => {
     return this._windowFinder != null;
   }
 
@@ -206,7 +206,7 @@ class DefaultProviderRegistry implements ProviderRegistry {
     this.getLogProvider().trace("Registered new WindowElementInspector provider", value);
   };
 
-  hasImageReader(): boolean {
+  hasImageReader = (): boolean => {
     return this._imageReader != null;
   }
 
@@ -224,7 +224,7 @@ class DefaultProviderRegistry implements ProviderRegistry {
     this.getLogProvider().trace("Registered new image reader", value);
   };
 
-  hasImageWriter(): boolean {
+  hasImageWriter = (): boolean => {
     return this._imageWriter != null;
   }
 
@@ -242,7 +242,7 @@ class DefaultProviderRegistry implements ProviderRegistry {
     this.getLogProvider().trace("Registered new image writer", value);
   };
 
-  hasImageProcessor(): boolean {
+  hasImageProcessor = (): boolean => {
     return this._imageProcessor != null;
   }
 
@@ -260,7 +260,7 @@ class DefaultProviderRegistry implements ProviderRegistry {
     this.getLogProvider().trace("Registered new image processor", value);
   };
 
-  hasLogProvider(): boolean {
+  hasLogProvider = (): boolean => {
     return this._logProvider != null;
   }
 
@@ -278,7 +278,7 @@ class DefaultProviderRegistry implements ProviderRegistry {
     this.getLogProvider().trace("Registered new log provider", value);
   };
 
-  hasColorFinder(): boolean {
+  hasColorFinder = (): boolean => {
     return this._colorFinder != null;
   }
 

--- a/core/nut.js/lib/screen.class.ts
+++ b/core/nut.js/lib/screen.class.ts
@@ -143,7 +143,7 @@ export class ScreenClass {
    * This refers to the hardware resolution.
    * Screens with higher pixel density (e.g. retina displays in MacBooks) might have a higher width in in actual pixels
    */
-  public width() {
+  public width = () => {
     this.providerRegistry.getLogProvider().debug(`Fetching screen width`);
     return this.providerRegistry.getScreen().screenWidth();
   }
@@ -153,7 +153,7 @@ export class ScreenClass {
    * This refers to the hardware resolution.
    * Screens with higher pixel density (e.g. retina displays in MacBooks) might have a higher height in in actual pixels
    */
-  public height() {
+  public height = () => {
     this.providerRegistry.getLogProvider().debug(`Fetching screen height`);
     return this.providerRegistry.getScreen().screenHeight();
   }
@@ -163,23 +163,25 @@ export class ScreenClass {
    * @param searchInput A {@link FindInput} instance
    * @param params {@link OptionalSearchParameters} which are used to fine tune search region and / or match confidence
    */
-  public async find<PROVIDER_DATA_TYPE>(
+  public find = this._find.bind(this);
+
+  private _find<PROVIDER_DATA_TYPE>(
     searchInput: RegionResultFindInput | Promise<RegionResultFindInput>,
     params?: OptionalSearchParameters<PROVIDER_DATA_TYPE>
   ): Promise<Region>;
-  public async find<PROVIDER_DATA_TYPE>(
+  private async _find<PROVIDER_DATA_TYPE>(
     searchInput: PointResultFindInput | Promise<PointResultFindInput>,
     params?: OptionalSearchParameters<PROVIDER_DATA_TYPE>
   ): Promise<Point>;
-  public async find<PROVIDER_DATA_TYPE>(
+  private async _find<PROVIDER_DATA_TYPE>(
     searchInput: WindowResultFindInput | Promise<WindowResultFindInput>,
     params?: OptionalSearchParameters<PROVIDER_DATA_TYPE>
   ): Promise<Window>;
-  public async find<PROVIDER_DATA_TYPE>(
+  private async _find<PROVIDER_DATA_TYPE>(
     searchInput: FindInput | Promise<FindInput>,
     params?: OptionalSearchParameters<PROVIDER_DATA_TYPE>
   ): Promise<FindResult>;
-  public async find<PROVIDER_DATA_TYPE>(
+  private async _find <PROVIDER_DATA_TYPE>(
     searchInput: FindInput | Promise<FindInput>,
     params?: OptionalSearchParameters<PROVIDER_DATA_TYPE>
   ): Promise<FindResult> {
@@ -314,23 +316,25 @@ export class ScreenClass {
    * @param searchInput A {@link FindInput} instance to search for
    * @param params {@link OptionalSearchParameters} which are used to fine tune search region and / or match confidence
    */
-  public async findAll<PROVIDER_DATA_TYPE>(
+  public findAll = this._findAll.bind(this);
+
+  private async _findAll<PROVIDER_DATA_TYPE>(
     searchInput: RegionResultFindInput | Promise<RegionResultFindInput>,
     params?: OptionalSearchParameters<PROVIDER_DATA_TYPE>
   ): Promise<Region[]>;
-  public async findAll<PROVIDER_DATA_TYPE>(
+  private async _findAll<PROVIDER_DATA_TYPE>(
     searchInput: PointResultFindInput | Promise<PointResultFindInput>,
     params?: OptionalSearchParameters<PROVIDER_DATA_TYPE>
   ): Promise<Point[]>;
-  public async findAll<PROVIDER_DATA_TYPE>(
+  private async _findAll<PROVIDER_DATA_TYPE>(
     searchInput: WindowResultFindInput | Promise<WindowResultFindInput>,
     params?: OptionalSearchParameters<PROVIDER_DATA_TYPE>
   ): Promise<Window[]>;
-  public async findAll<PROVIDER_DATA_TYPE>(
+  private async _findAll<PROVIDER_DATA_TYPE>(
     searchInput: FindInput | Promise<FindInput>,
     params?: OptionalSearchParameters<PROVIDER_DATA_TYPE>
   ): Promise<FindResult[]>;
-  public async findAll<PROVIDER_DATA_TYPE>(
+  private async _findAll <PROVIDER_DATA_TYPE>(
     searchInput: FindInput | Promise<FindInput>,
     params?: OptionalSearchParameters<PROVIDER_DATA_TYPE>
   ): Promise<FindResult[]> {
@@ -481,9 +485,9 @@ export class ScreenClass {
    * {@link highlight} highlights a screen {@link Region} for a certain duration by overlaying it with an opaque highlight window
    * @param regionToHighlight The {@link Region} to highlight
    */
-  public async highlight(
+  public highlight = async (
     regionToHighlight: Region | Promise<Region>
-  ): Promise<Region> {
+  ): Promise<Region> => {
     const highlightRegion = await regionToHighlight;
     if (!isRegion(highlightRegion)) {
       const e = Error(
@@ -518,25 +522,27 @@ export class ScreenClass {
    * @param updateInterval Update interval in milliseconds to retry search
    * @param params {@link OptionalSearchParameters} which are used to fine tune search region and / or match confidence
    */
-  public async waitFor<PROVIDER_DATA_TYPE>(
+  public waitFor = this._waitFor.bind(this);
+
+  private async _waitFor<PROVIDER_DATA_TYPE>(
     searchInput: RegionResultFindInput | Promise<RegionResultFindInput>,
     timeoutMs?: number,
     updateInterval?: number,
     params?: OptionalSearchParameters<PROVIDER_DATA_TYPE>
   ): Promise<Region>;
-  public async waitFor<PROVIDER_DATA_TYPE>(
+  private async _waitFor<PROVIDER_DATA_TYPE>(
     searchInput: PointResultFindInput | Promise<PointResultFindInput>,
     timeoutMs?: number,
     updateInterval?: number,
     params?: OptionalSearchParameters<PROVIDER_DATA_TYPE>
   ): Promise<Point>;
-  public async waitFor<PROVIDER_DATA_TYPE>(
+  private async _waitFor<PROVIDER_DATA_TYPE>(
     searchInput: WindowResultFindInput | Promise<WindowResultFindInput>,
     timeoutMs?: number,
     updateInterval?: number,
     params?: OptionalSearchParameters<PROVIDER_DATA_TYPE>
   ): Promise<Window>;
-  public async waitFor<PROVIDER_DATA_TYPE>(
+  private async _waitFor <PROVIDER_DATA_TYPE>(
     searchInput: FindInput | Promise<FindInput>,
     timeoutMs?: number,
     updateInterval?: number,
@@ -573,16 +579,18 @@ export class ScreenClass {
    * @param searchInput to trigger the callback on
    * @param callback The {@link FindHookCallback} function to trigger
    */
-  public on(searchInput: WindowResultFindInput, callback: WindowCallback): void;
-  public on(
+  public on = this._on.bind(this);
+
+  private _on(searchInput: WindowResultFindInput, callback: WindowCallback): void;
+  private _on(
     searchInput: PointResultFindInput,
     callback: MatchResultCallback<Point>
   ): void;
-  public on(
+  private _on(
     searchInput: RegionResultFindInput,
     callback: MatchResultCallback<Region>
   ): void;
-  public on(searchInput: FindInput, callback: FindHookCallback): void {
+  private _on(searchInput: FindInput, callback: FindHookCallback): void {
     this.validateSearchInput("on", searchInput);
 
     const existingHooks = this.findHooks.get(searchInput) ?? [];
@@ -604,13 +612,13 @@ export class ScreenClass {
    * @param fileNamePrefix Filename prefix for the generated screenshot (Default: empty)
    * @param fileNamePostfix Filename postfix for the generated screenshot (Default: empty)
    */
-  public async capture(
+  public capture = async (
     fileName: string,
     fileFormat: FileType = FileType.PNG,
     filePath: string = cwd(),
     fileNamePrefix: string = "",
     fileNamePostfix: string = ""
-  ): Promise<string> {
+  ): Promise<string> => {
     const currentScreen = await this.providerRegistry.getScreen().grabScreen();
     if (!isImage(currentScreen)) {
       const e = new Error(
@@ -639,7 +647,7 @@ export class ScreenClass {
   /**
    * {@link grab} grabs screen content of a systems main display
    */
-  public async grab(): Promise<Image> {
+  public grab = async (): Promise<Image> => {
     const currentScreen = await this.providerRegistry.getScreen().grabScreen();
     this.providerRegistry
       .getLogProvider()
@@ -658,14 +666,14 @@ export class ScreenClass {
    * @param fileNamePrefix Filename prefix for the generated screenshot (Default: empty)
    * @param fileNamePostfix Filename postfix for the generated screenshot (Default: empty)
    */
-  public async captureRegion(
+  public captureRegion = async (
     fileName: string,
     regionToCapture: Region | Promise<Region>,
     fileFormat: FileType = FileType.PNG,
     filePath: string = cwd(),
     fileNamePrefix: string = "",
     fileNamePostfix: string = ""
-  ): Promise<string> {
+  ): Promise<string> => {
     const targetRegion = await regionToCapture;
     if (!isRegion(targetRegion)) {
       const e = new Error(
@@ -705,9 +713,9 @@ export class ScreenClass {
    * {@link grabRegion} grabs screen content of a region on the systems main display
    * @param regionToGrab The screen region to grab
    */
-  public async grabRegion(
+  public grabRegion = async (
     regionToGrab: Region | Promise<Region>
-  ): Promise<Image> {
+  ): Promise<Image> => {
     const targetRegion = await regionToGrab;
     if (!isRegion(targetRegion)) {
       const e = new Error(
@@ -731,7 +739,7 @@ export class ScreenClass {
    * {@link colorAt} returns RGBA color values for a certain pixel at {@link Point} p
    * @param point Location to query color information from
    */
-  public async colorAt(point: Point | Promise<Point>) {
+  public colorAt = async (point: Point | Promise<Point>) => {
     const screenContent = await this.providerRegistry.getScreen().grabScreen();
     const inputPoint = await point;
     if (!isPoint(inputPoint)) {
@@ -763,14 +771,14 @@ export class ScreenClass {
     return color;
   }
 
-  private async saveImage(
+  private saveImage = async (
     image: Image,
     fileName: string,
     fileFormat: FileType,
     filePath: string,
     fileNamePrefix: string,
     fileNamePostfix: string
-  ) {
+  ) => {
     const outputPath = generateOutputPath(fileName, {
       path: filePath,
       postfix: fileNamePostfix,
@@ -787,9 +795,9 @@ export class ScreenClass {
     return outputPath;
   }
 
-  private async getFindParameters<PROVIDER_DATA_TYPE>(
+  private getFindParameters = async <PROVIDER_DATA_TYPE>(
     params?: OptionalSearchParameters<PROVIDER_DATA_TYPE>
-  ) {
+  ) => {
     const minMatch = params?.confidence;
     const screenSize = await this.providerRegistry.getScreen().screenSize();
     const searchRegion = (await params?.searchRegion) ?? screenSize;
@@ -813,14 +821,16 @@ export class ScreenClass {
     return findParameters;
   }
 
-  private getHooksForInput(input: WindowResultFindInput): WindowCallback[];
-  private getHooksForInput(
+  private getHooksForInput = this._getHooksForInput.bind(this);
+
+  private _getHooksForInput(input: WindowResultFindInput): WindowCallback[];
+  private _getHooksForInput(
     input: RegionResultFindInput
   ): MatchResultCallback<Region>[];
-  private getHooksForInput(
+  private _getHooksForInput(
     input: PointResultFindInput
   ): MatchResultCallback<Point>[];
-  private getHooksForInput(
+  private _getHooksForInput(
     input: FindInput
   ):
     | MatchResultCallback<Point>[]
@@ -836,7 +846,7 @@ export class ScreenClass {
     return [];
   }
 
-  private logNeedleType(needle: Image | WordQuery | LineQuery | ColorQuery) {
+  private logNeedleType = (needle: Image | WordQuery | LineQuery | ColorQuery) => {
     if (isImage(needle)) {
       this.providerRegistry.getLogProvider().debug(`Running an image search`);
     } else if (isTextQuery(needle)) {
@@ -844,7 +854,7 @@ export class ScreenClass {
     }
   }
 
-  private validateSearchInput(
+  private validateSearchInput = (
     functionName: string,
     needle:
       | Image
@@ -853,7 +863,7 @@ export class ScreenClass {
       | WindowResultFindInput
       | PointResultFindInput
       | Promise<FindInput>
-  ) {
+  ) => {
     if (
       !isImage(needle) &&
       !isTextQuery(needle) &&

--- a/core/nut.js/lib/window.class.ts
+++ b/core/nut.js/lib/window.class.ts
@@ -32,7 +32,7 @@ export class Window implements WindowInterface {
     return this.getTitle();
   }
 
-  async getTitle(): Promise<string> {
+  getTitle = async (): Promise<string> => {
     return this.providerRegistry.getWindow().getWindowTitle(this.windowHandle);
   }
 
@@ -40,7 +40,7 @@ export class Window implements WindowInterface {
     return this.getRegion();
   }
 
-  async getRegion(): Promise<Region> {
+  getRegion = async (): Promise<Region> => {
     const region = await this.providerRegistry.getWindow().getWindowRegion(this.windowHandle);
     const mainWindowRegion = await this.providerRegistry.getScreen().screenSize();
     if (region.left < 0) {
@@ -70,31 +70,31 @@ export class Window implements WindowInterface {
     return region;
   }
 
-  async move(newOrigin: Point) {
+  move = async (newOrigin: Point) => {
     return this.providerRegistry
       .getWindow()
       .moveWindow(this.windowHandle, newOrigin);
   }
 
-  async resize(newSize: Size) {
+  resize = async (newSize: Size) => {
     return this.providerRegistry
       .getWindow()
       .resizeWindow(this.windowHandle, newSize);
   }
 
-  async focus() {
+  focus = async () => {
     return this.providerRegistry.getWindow().focusWindow(this.windowHandle);
   }
 
-  async minimize() {
+  minimize = async () => {
     return this.providerRegistry.getWindow().minimizeWindow(this.windowHandle);
   }
 
-  async restore() {
+  restore = async () => {
     return this.providerRegistry.getWindow().restoreWindow(this.windowHandle);
   }
 
-  async getElements(maxElements?: number): Promise<WindowElement> {
+  getElements = async (maxElements?: number): Promise<WindowElement> => {
     return this.providerRegistry.getWindowElementInspector().getElements(this.windowHandle, maxElements);
   }
 
@@ -102,9 +102,9 @@ export class Window implements WindowInterface {
    * {@link find} will search for a single occurrence of a given search input in the current window.
    * @param searchInput A {@link WindowedFindInput} instance
    */
-  public async find(
+  public find = async (
     searchInput: WindowElementResultFindInput | Promise<WindowElementResultFindInput>
-  ): Promise<WindowElement> {
+  ): Promise<WindowElement> => {
     const needle = await searchInput;
     this.providerRegistry.getLogProvider().info(`Searching for ${needle} in window ${this.windowHandle}`);
 
@@ -140,9 +140,9 @@ export class Window implements WindowInterface {
    * {@link findAll} will search for multiple occurrence of a given search input in the current window.
    * @param searchInput A {@link WindowedFindInput} instance
    */
-  public async findAll(
+  public findAll = async (
     searchInput: WindowElementResultFindInput | Promise<WindowElementResultFindInput>
-  ): Promise<WindowElement[]> {
+  ): Promise<WindowElement[]> => {
     const needle = await searchInput;
     this.providerRegistry.getLogProvider().info(`Searching for ${needle} in window ${this.windowHandle}`);
 
@@ -183,12 +183,12 @@ export class Window implements WindowInterface {
    * @param updateInterval Update interval in milliseconds to retry search
    * @param params {@link OptionalSearchParameters} which are used to fine tune search
    */
-  public async waitFor<PROVIDER_DATA_TYPE>(
+  public waitFor = async <PROVIDER_DATA_TYPE>(
     searchInput: WindowElementQuery | Promise<WindowElementQuery>,
     timeoutMs?: number,
     updateInterval?: number,
     params?: OptionalSearchParameters<PROVIDER_DATA_TYPE>
-  ): Promise<WindowElement> {
+  ): Promise<WindowElement> => {
     const needle = await searchInput;
 
     const timeoutValue = timeoutMs ?? 5000;
@@ -218,7 +218,7 @@ export class Window implements WindowInterface {
    * @param searchInput to trigger the callback on
    * @param callback The {@link FindHookCallback} function to trigger
    */
-  public on(searchInput: WindowElementQuery, callback: WindowElementCallback): void {
+  public on = (searchInput: WindowElementQuery, callback: WindowElementCallback): void => {
     const existingHooks = this.getHooksForInput(searchInput);
     this.findHooks.set(searchInput, [...existingHooks, callback]);
     this.providerRegistry
@@ -230,9 +230,9 @@ export class Window implements WindowInterface {
       );
   }
 
-  private getHooksForInput(
+  private getHooksForInput = (
     input: WindowElementQuery
-  ): WindowElementCallback[] {
+  ): WindowElementCallback[] => {
     return this.findHooks.get(input) ?? [];
   }
 }

--- a/core/shared/lib/objects/image.class.ts
+++ b/core/shared/lib/objects/image.class.ts
@@ -46,7 +46,7 @@ export class Image {
   /**
    * {@link toRGB} converts an {@link Image} from BGR color mode (default within nut.js) to RGB
    */
-  public async toRGB(): Promise<Image> {
+  public toRGB = async (): Promise<Image> => {
     if (this.colorMode === ColorMode.RGB) {
       return this;
     }
@@ -67,7 +67,7 @@ export class Image {
   /**
    * {@link toBGR} converts an {@link Image} from RGB color mode to RGB
    */
-  public async toBGR(): Promise<Image> {
+  public toBGR = async (): Promise<Image> => {
     if (this.colorMode === ColorMode.BGR) {
       return this;
     }

--- a/core/shared/lib/objects/point.class.ts
+++ b/core/shared/lib/objects/point.class.ts
@@ -1,7 +1,7 @@
 export class Point {
   constructor(public x: number, public y: number) {}
 
-  public toString() {
+  public toString = () => {
     return `(${this.x}, ${this.y})`;
   }
 }

--- a/core/shared/lib/objects/region.class.ts
+++ b/core/shared/lib/objects/region.class.ts
@@ -6,11 +6,11 @@ export class Region {
     public height: number
   ) {}
 
-  public area() {
+  public area = () => {
     return this.width * this.height;
   }
 
-  public toString() {
+  public toString = () => {
     return `(${this.left}, ${this.top}, ${this.width}, ${this.height})`;
   }
 }

--- a/core/shared/lib/objects/rgba.class.ts
+++ b/core/shared/lib/objects/rgba.class.ts
@@ -7,11 +7,11 @@ export class RGBA {
   ) {
   }
 
-  public toString(): string {
+  public toString = (): string => {
     return `rgba(${this.R},${this.G},${this.B},${this.A})`;
   }
 
-  public toHex(): string {
+  public toHex = (): string => {
     return `#${this.R.toString(16).padStart(2, "0")}${this.G.toString(
       16
     ).padStart(2, "0")}${this.B.toString(16).padStart(2, "0")}${this.A.toString(

--- a/core/shared/lib/objects/size.class.ts
+++ b/core/shared/lib/objects/size.class.ts
@@ -4,11 +4,11 @@ export class Size {
     public height: number,
   ) {}
 
-  public area() {
+  public area = () => {
     return this.width * this.height;
   }
 
-  public toString() {
+  public toString = () => {
     return `(${this.width}x${this.height})`;
   }
 }

--- a/providers/libnut/lib/libnut-keyboard.class.ts
+++ b/providers/libnut/lib/libnut-keyboard.class.ts
@@ -150,21 +150,21 @@ export default class KeyboardAction implements KeyboardProviderInterface {
     [Key.AudioRandom, "audio_random"]
   ]);
 
-  public static keyLookup(key: Key): any {
+  public static keyLookup = (key: Key): any => {
     return this.KeyLookupMap.get(key);
   }
 
-  private static mapModifierKeys(...keys: Key[]): string[] {
+  private static mapModifierKeys = (...keys: Key[]): string[] => {
     return keys
       .map((modifier) => KeyboardAction.keyLookup(modifier))
       .filter((modifierKey) => modifierKey != null && modifierKey.length > 1);
   }
 
-  private static key(
+  private static key = (
     key: Key,
     event: "up" | "down",
     ...modifiers: Key[]
-  ): Promise<void> {
+  ): Promise<void>  => {
     return new Promise<void>((resolve, reject) => {
       try {
         const nativeKey = KeyboardAction.keyLookup(key);
@@ -182,7 +182,7 @@ export default class KeyboardAction implements KeyboardProviderInterface {
   constructor() {
   }
 
-  public type(input: string): Promise<void> {
+  public type = (input: string): Promise<void> => {
     return new Promise<void>((resolve, reject) => {
       try {
         libnut.typeString(input);
@@ -193,7 +193,7 @@ export default class KeyboardAction implements KeyboardProviderInterface {
     });
   }
 
-  public click(...keys: Key[]): Promise<void> {
+  public click = (...keys: Key[]): Promise<void> => {
     return new Promise<void>((resolve, reject) => {
       try {
         keys.reverse();
@@ -210,7 +210,7 @@ export default class KeyboardAction implements KeyboardProviderInterface {
     });
   }
 
-  public pressKey(...keys: Key[]): Promise<void> {
+  public pressKey = (...keys: Key[]): Promise<void> => {
     return new Promise<void>(async (resolve, reject) => {
       try {
         keys.reverse();
@@ -223,7 +223,7 @@ export default class KeyboardAction implements KeyboardProviderInterface {
     });
   }
 
-  public releaseKey(...keys: Key[]): Promise<void> {
+  public releaseKey = (...keys: Key[]): Promise<void> => {
     return new Promise<void>(async (resolve, reject) => {
       try {
         keys.reverse();
@@ -236,7 +236,7 @@ export default class KeyboardAction implements KeyboardProviderInterface {
     });
   }
 
-  public setKeyboardDelay(delay: number): void {
+  public setKeyboardDelay = (delay: number): void => {
     libnut.setKeyboardDelay(delay);
   }
 }

--- a/providers/libnut/lib/libnut-mouse.class.ts
+++ b/providers/libnut/lib/libnut-mouse.class.ts
@@ -3,7 +3,7 @@ import { Button, Point } from "@nut-tree/shared";
 import { MouseProviderInterface } from "@nut-tree/provider-interfaces";
 
 export default class MouseAction implements MouseProviderInterface {
-  public static buttonLookup(btn: Button): any {
+  public static buttonLookup = (btn: Button): any => {
     return this.ButtonLookupMap.get(btn);
   }
 
@@ -18,11 +18,11 @@ export default class MouseAction implements MouseProviderInterface {
   constructor() {
   }
 
-  public setMouseDelay(delay: number): void {
+  public setMouseDelay = (delay: number): void => {
     libnut.setMouseDelay(delay);
   }
 
-  public setMousePosition(p: Point): Promise<void> {
+  public setMousePosition = (p: Point): Promise<void> => {
     return new Promise<void>((resolve, reject) => {
       try {
         libnut.moveMouse(p.x, p.y);
@@ -33,7 +33,7 @@ export default class MouseAction implements MouseProviderInterface {
     });
   }
 
-  public currentMousePosition(): Promise<Point> {
+  public currentMousePosition = (): Promise<Point> => {
     return new Promise<Point>((resolve, reject) => {
       try {
         const position = libnut.getMousePos();
@@ -44,7 +44,7 @@ export default class MouseAction implements MouseProviderInterface {
     });
   }
 
-  public click(btn: Button): Promise<void> {
+  public click = (btn: Button): Promise<void> => {
     return new Promise<void>((resolve, reject) => {
       try {
         libnut.mouseClick(MouseAction.buttonLookup(btn));
@@ -55,7 +55,7 @@ export default class MouseAction implements MouseProviderInterface {
     });
   }
 
-  public doubleClick(btn: Button): Promise<void> {
+  public doubleClick = (btn: Button): Promise<void> => {
     return new Promise<void>((resolve, reject) => {
       try {
         libnut.mouseClick(MouseAction.buttonLookup(btn), true);
@@ -66,19 +66,19 @@ export default class MouseAction implements MouseProviderInterface {
     });
   }
 
-  public leftClick(): Promise<void> {
+  public leftClick = (): Promise<void> => {
     return this.click(Button.LEFT);
   }
 
-  public rightClick(): Promise<void> {
+  public rightClick = (): Promise<void> => {
     return this.click(Button.RIGHT);
   }
 
-  public middleClick(): Promise<void> {
+  public middleClick = (): Promise<void> => {
     return this.click(Button.MIDDLE);
   }
 
-  public pressButton(btn: Button): Promise<void> {
+  public pressButton = (btn: Button): Promise<void> => {
     return new Promise<void>((resolve, reject) => {
       try {
         libnut.mouseToggle("down", MouseAction.buttonLookup(btn));
@@ -89,7 +89,7 @@ export default class MouseAction implements MouseProviderInterface {
     });
   }
 
-  public releaseButton(btn: Button): Promise<void> {
+  public releaseButton = (btn: Button): Promise<void> => {
     return new Promise<void>((resolve, reject) => {
       try {
         libnut.mouseToggle("up", MouseAction.buttonLookup(btn));
@@ -100,7 +100,7 @@ export default class MouseAction implements MouseProviderInterface {
     });
   }
 
-  public scrollUp(amount: number): Promise<void> {
+  public scrollUp = (amount: number): Promise<void> => {
     return new Promise<void>((resolve, reject) => {
       try {
         libnut.scrollMouse(0, amount);
@@ -111,7 +111,7 @@ export default class MouseAction implements MouseProviderInterface {
     });
   }
 
-  public scrollDown(amount: number): Promise<void> {
+  public scrollDown = (amount: number): Promise<void> => {
     return new Promise<void>((resolve, reject) => {
       try {
         libnut.scrollMouse(0, -amount);
@@ -122,7 +122,7 @@ export default class MouseAction implements MouseProviderInterface {
     });
   }
 
-  public scrollLeft(amount: number): Promise<void> {
+  public scrollLeft = (amount: number): Promise<void> => {
     return new Promise<void>((resolve, reject) => {
       try {
         libnut.scrollMouse(-amount, 0);
@@ -133,7 +133,7 @@ export default class MouseAction implements MouseProviderInterface {
     });
   }
 
-  public scrollRight(amount: number): Promise<void> {
+  public scrollRight = (amount: number): Promise<void> => {
     return new Promise<void>((resolve, reject) => {
       try {
         libnut.scrollMouse(amount, 0);


### PR DESCRIPTION
This pull request binds all class methods using the `this` keyword, so that don't break in certain circumstances, like calling methods dynamically (i.e. using the `get` function from `lodash`).

Also, I don't want to break your workflow and it's beyond the scope of this pull request, but having `@nut-tree/nl-matcher` as a dependency breaks `pnpm install` if one doesn't have access to it, so a contributor would need to uninstall it first from the examples workspace. Something to keep in mind.