### PR TITLE
Fix typos in the documentation

### DIFF
--- a/core/nut.js/lib/screen.class.ts
+++ b/core/nut.js/lib/screen.class.ts
@@ -139,9 +139,9 @@ export class ScreenClass {
   }
 
   /**
-   * {@link width} returns the main screen width
+   * {@link width} returns the main screen width  
    * This refers to the hardware resolution.
-   * Screens with higher pixel density (e.g. retina displays in MacBooks) might have a higher width in in actual pixels
+   * Screens with higher pixel density (e.g. retina displays in MacBooks) might have a higher width in actual pixels
    */
   public width() {
     this.providerRegistry.getLogProvider().debug(`Fetching screen width`);
@@ -149,9 +149,9 @@ export class ScreenClass {
   }
 
   /**
-   * {@link height} returns the main screen height
+   * {@link height} returns the main screen height  
    * This refers to the hardware resolution.
-   * Screens with higher pixel density (e.g. retina displays in MacBooks) might have a higher height in in actual pixels
+   * Screens with higher pixel density (e.g. retina displays in MacBooks) might have a higher height in actual pixels
    */
   public height() {
     this.providerRegistry.getLogProvider().debug(`Fetching screen height`);

--- a/core/shared/lib/objects/image.class.ts
+++ b/core/shared/lib/objects/image.class.ts
@@ -65,7 +65,7 @@ export class Image {
   }
 
   /**
-   * {@link toBGR} converts an {@link Image} from RGB color mode to RGB
+   * {@link toBGR} converts an {@link Image} from RGB color mode to BGR
    */
   public async toBGR(): Promise<Image> {
     if (this.colorMode === ColorMode.BGR) {

--- a/examples/screen-test/README.md
+++ b/examples/screen-test/README.md
@@ -52,7 +52,7 @@ Following this scheme loading of platform specific images would be possible with
 ## [`find`](https://nut-tree.github.io/apidoc/classes/screen.html#find)
 
 `find` takes a filename relative to the configured [resourceDirectory](#resourcedirectory) and tries to find a match on the main screen.
-It is possible to override the the [configured matching confidence](#confidence) and search region providing [LocationParameters](https://nut-tree.github.io/apidoc/classes/locationparameters.html).
+It is possible to override the [configured matching confidence](#confidence) and search region providing [LocationParameters](https://nut-tree.github.io/apidoc/classes/locationparameters.html).
 In case of a match, the corresponding [Region](https://nut-tree.github.io/apidoc/classes/region.html) on screen is returned.
 
 ```js


### PR DESCRIPTION
Changed "toBGR converts an Image from RGB color mode to RGB" to "toBGR converts an Image from RGB color mode to BGR" and fixed various typos in other files.